### PR TITLE
Make method private

### DIFF
--- a/src/main/java/anita/Task.java
+++ b/src/main/java/anita/Task.java
@@ -22,7 +22,7 @@ public abstract class Task {
      *
      * @return 'X' if task is completed else " ".
      */
-    public String getStatusIcon() {
+    private String getStatusIcon() {
         return (isDone ? "X" : " ");
     }
 

--- a/src/main/java/anita/TaskList.java
+++ b/src/main/java/anita/TaskList.java
@@ -28,7 +28,7 @@ public class TaskList {
      * @param index Index of the item to be retrieved.
      * @return Task to be retrieved.
      */
-    public Task get(int index) {
+    private Task get(int index) {
         return taskList.get(index - 1);
     }
 


### PR DESCRIPTION
Some methods in the codebase are unnecessarily written as public.

To enhance code maintainability and prevent unintended modification or misuse of internal functionality. Restricting access to these methods can enforce better encapsulation and reduce the risk of introducing unexpected behaviour during future modifications.

Identified public methods get(int index) in TaskList class and getStatusIcon() in the Task abstract class are being refactored to private access modifiers.

Making these methods private encapsulates their behaviour, limiting their visibility and access to other parts of the codebase.